### PR TITLE
correct typo in filename

### DIFF
--- a/Samplefiles/samplefile1_manhattan.csv
+++ b/Samplefiles/samplefile1_manhattan.csv
@@ -1,4 +1,4 @@
-﻿timepoint,marker,chrom,pos,P
+timepoint,marker,chrom,pos,P
 1,SNP-1.131482.,1,132483,0.000342505
 1,SNP-1.686571.,1,687572,0.00030756
 1,SNP-1.866303.,1,867304,0.000670995


### PR DESCRIPTION
Use "manhattan" instead of "manhatten" so that link from Shiny app works